### PR TITLE
LPS-168131 Fix ApplicationsMenu#PORTLET path

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>PORTLET</td>
-	<td>//div[contains(@role,'tabpanel') and contains(@class,'active')]//div[contains(@class,'applications-menu-nav-columns')]//li[contains(.,'${key_category}')]//../li//span[normalize-space(text())='${key_portlet}']</td>
+	<td>//div[contains(@role,'tabpanel') and contains(@class,'active')]//div[contains(@class,'applications-menu-nav-columns')]//div[contains(.,'${key_category}')]//../li//span[normalize-space(text())='${key_portlet}']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/129962. Seems that commit didn't fully fix the path and now many tests are failing because of it, making analysis difficult.