### PR TITLE
LRQA-84210 | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -10855,7 +10855,7 @@ send_user $expect_out(buffer)]]></echo>
 		/>
 
 		<echo file="${app.server.bin.dir}/gogo-command.sh">
-service = {$.context service ([($.context servicereferences $1 $2)] get 0)};
+service = { $.context service ([($.context servicereferences $1 $2)] get 0) };
 
 script = ($.context getService (($.context getServiceReferences com.liferay.portal.kernel.util.File null) 0)) read ${test.app.server.liferay.home}/portal-script.groovy;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRQA-84210

Without it this error is thrown
```
gogo: IOException: no matches found: {org.eclipse.osgi.internal.framework.BundleContextImpl@2a318fb service ([(org.eclipse.osgi.internal.framework.BundleContextImpl@2a318fb servicereferences  )] get 0)}
```
